### PR TITLE
Upgrade deps (fastmcp 3.4.2), remove embeddings/vector-store, and harden image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.venv/
+.git/
+__pycache__/
+**/__pycache__/
+*.pyc
+*.pyo
+*.pyd
+logs/
+src/logs/
+.env
+.DS_Store
+.claude/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*    
 
-# Install uv
-RUN pip install --no-cache-dir uv
+# Install uv, and refresh the base image's build tooling to clear known CVEs
+# in setuptools (which vendors jaraco.context) and wheel.
+RUN pip install --no-cache-dir --upgrade uv setuptools wheel
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
Upgrades the core dependency stack, removes the embeddings/vector-store feature, and hardens the Docker image. Net `-1082` lines.

### Dependencies & feature removal

- Bumps to `fastmcp>=3.4.2` (and the transitive stack it pulls), `asyncmy>=0.2.11`, `python-dotenv>=1.2.2`.
- Removes the embeddings/vector-store feature entirely: deletes `src/embeddings.py`, slims `src/server.py` and `src/config.py`, and drops the now-dead `test_embedding_service.py` / `test_mcp_server.py`.
- Adds `src/tests/smoke_test.py` — a standalone in-memory check that exercises the core MCP tools (`list_databases`, `list_tables`, `get_table_schema`, `execute_sql`) against a live MariaDB via FastMCP's in-memory client.

### Image hardening

- Refreshes the base image's build tooling (`pip install --upgrade setuptools wheel`) so `python:3.11-slim`'s vendored `jaraco.context` (`CVE-2026-23949`) and `wheel` (`CVE-2026-24049`) no longer flag.
- Adds `.dockerignore` so `COPY . /app` stops dragging the local `.venv`, `.git`, `logs/`, and `.env` into the image.

### Verification

- `docker build` + `trivy image --severity HIGH,CRITICAL --ignore-unfixed`: **0 fixable findings** (previously `wheel`/`jaraco.context`, plus a stale-lock `cryptography`/`urllib3` set that a fresh resolve clears — `cryptography 49.0.0`, `urllib3` dropped).
- `src/tests/smoke_test.py` against a live MariaDB 11: **all tools pass**.
